### PR TITLE
Fix pub-sub

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,5 +8,8 @@
   ],
   "plugins": [
     "require-path-exists"
-  ]
+  ],
+  "rules": {
+    "promise/no-promise-in-callback": "off"
+  }
 }

--- a/events/src/listener.js
+++ b/events/src/listener.js
@@ -7,19 +7,26 @@ const getPubsSub = require('../../shared/src/pubsub')
 function attachToDb (config, io) {
   const sub = getPubsSub(config.redis.url)
 
+  const { dbnum } = sub
+
   sub.on('pmessage', function (pattern, channel, message) {
     logger.verbose('Received new event %s %s', pattern, channel)
 
-    const [event, room] = channel.split(':')
+    const [_dbnum, event, room] = channel.split(':')
     const [txid, status] = message.split(':')
 
     const data = { type: 'eth', txid, status }
+
+    if (_dbnum !== dbnum) {
+      logger.warn('Received event from invalid keyspace')
+      return
+    }
 
     logger.verbose('<<-- %s %s %s %s', room, event, data.txid, data.status)
     io.to(room).emit(event, data)
   })
 
-  return sub.psubscribe('tx:*')
+  return sub.psubscribe(`${dbnum}:tx:*`)
 }
 
 module.exports = attachToDb

--- a/indexer/src/storage.js
+++ b/indexer/src/storage.js
@@ -6,6 +6,8 @@ const logger = require('../../shared/src/logger')
 const NULL_TX_ID = '0x0000000000000000000000000000000000000000000000000000000000000000'
 
 function init (db, pub) {
+  const { dbnum } = pub
+
   // Store ETH transaction data
   const storeEthTransactions = ({ number, data: { addresses, txid } }) =>
     Promise.all(addresses.map(function (addr) {
@@ -14,7 +16,7 @@ function init (db, pub) {
         db.setAddressTransaction({ addr, number, txid })
           .then(function () {
             logger.verbose('Publishing tx confirmed %s %s', addr, txid)
-            return pub.publish(`tx:${addr}`, `${txid}:confirmed`)
+            return pub.publish(`${dbnum}:tx:${addr}`, `${txid}:confirmed`)
           }),
         db.setBlockAddress({ number, addr })
       ])
@@ -35,7 +37,7 @@ function init (db, pub) {
             return db.deleteAddressTransaction({ addr, txid })
               .then(function () {
                 logger.verbose('Publishing tx unconfirmed %s %s', addr, txid)
-                return pub.publish(`tx:${addr}`, `${txid}:unconfirmed`)
+                return pub.publish(`${dbnum}:tx:${addr}`, `${txid}:unconfirmed`)
               })
           })))
         )

--- a/indexer/test/indexer.src.storage.spec.js
+++ b/indexer/test/indexer.src.storage.spec.js
@@ -16,7 +16,10 @@ describe('Parser storage', function () {
 
     const notifications = []
 
+    const dbnum = '0'
+
     const pubSubStub = {
+      dbnum,
       publish (event, data) {
         notifications.push({ event, data })
       }
@@ -56,8 +59,8 @@ describe('Parser storage', function () {
 
         notifications.should.have.lengthOf(2)
         notifications.should.have.deep.members([
-          { event: 'tx:0x31', data: '0x0431:unconfirmed' },
-          { event: 'tx:0x40', data: '0x0440:unconfirmed' }
+          { event: `${dbnum}:tx:0x31`, data: '0x0431:unconfirmed' },
+          { event: `${dbnum}:tx:0x40`, data: '0x0440:unconfirmed' }
         ])
       })
   })

--- a/shared/src/db/mongo.js
+++ b/shared/src/db/mongo.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const beforeExit = require('before-exit')
 const logger = require('../logger')
 const MongoClient = require('mongodb').MongoClient
 
@@ -10,6 +11,10 @@ const createClientFor = function (url) {
   // Handle errors
   db.on('error', function (err) {
     logger.error('Mongo error', err)
+
+    const meta = { inner: err, exitCode: 1 }
+    const error = Object.assign(new Error('Mongo error'), meta)
+    beforeExit(() => Promise.reject(error))
 
     // Can't continue if there is a database error
     process.kill(process.pid, 'SIGINT')

--- a/shared/src/db/redis.js
+++ b/shared/src/db/redis.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const beforeExit = require('before-exit')
 const redis = require('redis')
 const util = require('util')
 
@@ -12,6 +13,10 @@ function createClient ({ url }, maxBlocks) {
   // Handle errors
   client.on('error', function (err) {
     logger.error('Redis error', err)
+
+    const meta = { inner: err, exitCode: 1 }
+    const error = Object.assign(new Error('Redis error'), meta)
+    beforeExit(() => Promise.reject(error))
 
     // Can't continue if there is a database error
     process.kill(process.pid, 'SIGINT')

--- a/shared/src/pubsub.js
+++ b/shared/src/pubsub.js
@@ -1,19 +1,33 @@
 'use strict'
 
 const redis = require('redis')
+const url = require('url')
 const util = require('util')
 
 const logger = require('./logger')
 
+// Try to parse a URL using the global URL object in Node 10 or fallback to
+// legacy `url` module instead.
+function parseUrl (_url) {
+  try {
+    return new URL(_url)
+  } catch (err) {
+    return new url.URL(_url)
+  }
+}
+
 // Create and return a Redis Pub-Sub client
-function createRedisPubSub (url) {
-  const client = redis.createClient(url)
+function createRedisPubSub (redisUrl) {
+  logger.debug('Attaching to pubsub on %s', redisUrl)
+
+  const client = redis.createClient(redisUrl)
 
   client.on('error', function (err) {
     logger.error('Redis pubsub error', err)
   })
 
   return {
+    dbnum: parseUrl(redisUrl).pathname.replace(/^\//, '') || '0',
     on: client.on.bind(client),
     psubscribe: util.promisify(client.psubscribe.bind(client)),
     publish: util.promisify(client.publish.bind(client)),


### PR DESCRIPTION
When using the same Redis engine for different indexers, pub-sub messages must be prefixed to avoid mixing events across all indexer instances.